### PR TITLE
qualify overload of String

### DIFF
--- a/src/string.jl
+++ b/src/string.jl
@@ -40,7 +40,7 @@ As in Fortran, the string will be padded with spaces or truncated in order to re
 """
 FString(L, s::String) = convert( FString{L}, s )
 
-String(s::FString{L}) where {L} = String(map(Char,s.data))
+Base.String(s::FString{L}) where {L} = String(map(Char,s.data))
 Base.convert(::Type{String}, s::FString{L}) where {L} = String(s)
 
 


### PR DESCRIPTION

In Julia 1.12 a warning is issued for non-qualified imports, and in the future this might be an error. Here I qualified the overload of `String`.