### PR TITLE
add changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,12 @@
+name: changelog
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  # Can be skipped with the `Skip-Changelog` label
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+FortranFiles.jl Changelog
+===========================
+  
+[badge-breaking]: https://img.shields.io/badge/BREAKING-red.svg
+[badge-deprecation]: https://img.shields.io/badge/Deprecation-orange.svg
+[badge-feature]: https://img.shields.io/badge/Feature-green.svg
+[badge-experimental]: https://img.shields.io/badge/Experimental-yellow.svg
+[badge-enhancement]: https://img.shields.io/badge/Enhancement-blue.svg
+[badge-bugfix]: https://img.shields.io/badge/Bugfix-purple.svg
+[badge-fix]: https://img.shields.io/badge/Fix-purple.svg
+[badge-info]: https://img.shields.io/badge/Info-gray.svg
+
+Version 0.6.1-DEV
+-------------
+- ![FEATURE][badge-feature] Support `do` syntax.
+- ![INFO][badge-info] Qualify import of String
+- ![INFO][badge-info] Add CI and format code.
+- ![INFO][badge-info] Add CHANGELOG file and changelog CI.
+
+
+

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name    = "FortranFiles"
 uuid    = "c58ffaec-ab22-586d-bfc5-781a99fd0b10"
 author  = ["Frank Otto <traktofon@gmail.com>"]
-version = "0.6.0"
+version = "0.6.1-DEV"
 
 [compat]
 julia = "1"


### PR DESCRIPTION
Add changelog file and CI to check that every PR has a changelog entry.

The CHANGELOG.md file looks like:

![Screenshot_20250629_220327_Chrome](https://github.com/user-attachments/assets/3cbd1c86-0b4d-4208-a72b-2407c8bf3b76)

The changelog ci run fails if a PR does not add a changelog entry. This is nice because tracking changes becomes very easy, and the release process is much clearer.

